### PR TITLE
Make DataFrame and Series/Index manage the connection with each other.

### DIFF
--- a/databricks/koalas/base.py
+++ b/databricks/koalas/base.py
@@ -17,6 +17,7 @@
 """
 Base and utility classes for Koalas objects.
 """
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from functools import wraps, partial
 from typing import Union, Callable, Any
@@ -118,22 +119,27 @@ def numpy_column_op(f):
     return wrapper
 
 
-class IndexOpsMixin(object):
+class IndexOpsMixin(object, metaclass=ABCMeta):
     """common ops mixin to support a unified interface / docs for Series / Index
 
     Assuming there are following attributes or properties and function.
 
-    :ivar _kdf: Parent's Koalas DataFrame
-    :type _kdf: ks.DataFrame
-    :ivar spark: Spark-related features
-    :type spark: SparkIndexOpsMethods
+    :ivar _anchor: Parent's Koalas DataFrame
+    :type _anchor: ks.DataFrame
     """
 
-    def __init__(self, internal: InternalFrame, kdf):
-        assert internal is not None
-        assert kdf is not None and isinstance(kdf, DataFrame)
-        self._internal = internal  # type: InternalFrame
-        self._kdf = kdf
+    def __init__(self, anchor: DataFrame):
+        assert anchor is not None
+        self._anchor = anchor
+
+    @property
+    @abstractmethod
+    def _internal(self) -> InternalFrame:
+        pass
+
+    @property
+    def _kdf(self) -> DataFrame:
+        return self._anchor
 
     spark = CachedAccessor("spark", SparkIndexOpsMethods)
 

--- a/databricks/koalas/frame.py
+++ b/databricks/koalas/frame.py
@@ -315,7 +315,7 @@ class DataFrame(Frame, Generic[T]):
     internally.
 
     :ivar _internal: an internal immutable Frame to manage metadata.
-    :type _internal: _InternalFrame
+    :type _internal: InternalFrame
 
     Parameters
     ----------
@@ -390,20 +390,20 @@ class DataFrame(Frame, Generic[T]):
             assert columns is None
             assert dtype is None
             assert not copy
-            super(DataFrame, self).__init__(data)
+            internal = data
         elif isinstance(data, spark.DataFrame):
             assert index is None
             assert columns is None
             assert dtype is None
             assert not copy
-            super(DataFrame, self).__init__(InternalFrame(spark_frame=data, index_map=None))
+            internal = InternalFrame(spark_frame=data, index_map=None)
         elif isinstance(data, ks.Series):
             assert index is None
             assert columns is None
             assert dtype is None
             assert not copy
-            data = data.to_dataframe()
-            super(DataFrame, self).__init__(data._internal)
+            data = data.to_frame()
+            internal = data._internal
         else:
             if isinstance(data, pd.DataFrame):
                 assert index is None
@@ -413,7 +413,88 @@ class DataFrame(Frame, Generic[T]):
                 pdf = data
             else:
                 pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
-            super(DataFrame, self).__init__(InternalFrame.from_pandas(pdf))
+            internal = InternalFrame.from_pandas(pdf)
+
+        self._internal_frame = internal
+
+    @property
+    def _ksers(self):
+        """ Return a dict of column label -> Series which anchors `self`. """
+        from databricks.koalas.series import Series
+
+        if not hasattr(self, "_kseries"):
+            self._kseries = {
+                label: Series(data=self, index=label) for label in self._internal.column_labels
+            }
+        else:
+            kseries = self._kseries
+            assert len(self._internal.column_labels) == len(kseries), (
+                len(self._internal.column_labels),
+                len(kseries),
+            )
+            if any(self is not kser._kdf for kser in kseries.values()):
+                # Refresh the dict to contain only Series anchoring `self`.
+                self._kseries = {
+                    label: kseries[label]
+                    if self is kseries[label]._kdf
+                    else Series(data=self, index=label)
+                    for label in self._internal.column_labels
+                }
+        return self._kseries
+
+    @property
+    def _internal(self) -> InternalFrame:
+        return self._internal_frame
+
+    def _update_internal_frame(self, internal: InternalFrame, requires_same_anchor: bool = True):
+        """
+        Update InternalFrame with the given one.
+
+        If the column_label is changed or the new InternalFrame is not the same `anchor`,
+        disconnect the link to the Series and create a new one.
+
+        If `requires_same_anchor` is `False`, checking whether or not the same anchor is ignored
+        and force to update the InternalFrame, e.g., replacing the internal with the resolved_copy,
+        updating the underlying Spark DataFrame which need to combine a different Spark DataFrame.
+
+        :param internal: the new InternalFrame
+        :param requires_same_anchor: whether checking the same anchor
+        """
+        from databricks.koalas.series import Series
+
+        kseries = {}
+
+        for old_label, new_label in zip_longest(
+            self._internal.column_labels, internal.column_labels
+        ):
+            if old_label is not None:
+                kser = self._ksers[old_label]
+
+                renamed = old_label != new_label
+                not_same_anchor = requires_same_anchor and not same_anchor(internal, kser)
+
+                if renamed or not_same_anchor:
+                    kdf = DataFrame(
+                        self._internal.copy(
+                            column_labels=[old_label],
+                            data_spark_columns=[self._internal.spark_column_for(old_label)],
+                        )
+                    )  # type: DataFrame
+                    kser._anchor = kdf
+                    kdf._kseries = {old_label: kser}
+                    kser = None
+            else:
+                kser = None
+            if new_label is not None:
+                if kser is None:
+                    kser = Series(data=self, index=new_label)
+                kseries[new_label] = kser
+
+        self._internal_frame = internal
+        self._kseries = kseries
+
+        if hasattr(self, "_repr_pandas_cache"):
+            del self._repr_pandas_cache
 
     @property
     def ndim(self):
@@ -551,13 +632,13 @@ class DataFrame(Frame, Generic[T]):
         """
         Create Series with a proper column label.
 
-        The given label must be verified to exist in `_InternalFrame.column_labels`.
+        The given label must be verified to exist in `InternalFrame.column_labels`.
 
         For example, in some method, self is like:
 
         >>> self = ks.range(3)
 
-        `self._kser_for(label)` can be used with `_InternalFrame.column_labels`:
+        `self._kser_for(label)` can be used with `InternalFrame.column_labels`:
 
         >>> self._kser_for(self._internal.column_labels[0])
         0    0
@@ -574,14 +655,7 @@ class DataFrame(Frame, Generic[T]):
         2    2
         Name: id, dtype: int64
         """
-        from databricks.koalas.series import Series
-
-        return Series(
-            self._internal.copy(
-                spark_column=self._internal.spark_column_for(label), column_labels=[label]
-            ),
-            anchor=self,
-        )
+        return self._ksers[label]
 
     def _apply_series_op(self, op):
         applied = []
@@ -2719,7 +2793,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Name: B, dtype: int64
         """
         from databricks.koalas.groupby import GroupBy
-        from databricks.koalas import Series
+        from databricks.koalas.series import first_series
 
         assert callable(func), "the first argument should be a callable function."
         spec = inspect.getfullargspec(func)
@@ -2776,11 +2850,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 columns = self._internal.spark_columns
                 # TODO: Index will be lost in this case.
                 internal = self._internal.copy(
-                    spark_column=pudf(F.struct(*columns)) if should_by_pass else pudf(*columns),
                     column_labels=kser._internal.column_labels,
+                    data_spark_columns=[
+                        (pudf(F.struct(*columns)) if should_by_pass else pudf(*columns)).alias(
+                            kser._internal.data_spark_column_names[0]
+                        )
+                    ],
                     column_label_names=kser._internal.column_label_names,
                 )
-                return Series(internal, anchor=self)
+                return first_series(DataFrame(internal))
             else:
                 kdf = kdf_or_kser
                 if len(pdf) <= limit:
@@ -2840,11 +2918,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
                 columns = self._internal.spark_columns
                 internal = self._internal.copy(
-                    spark_column=pudf(F.struct(*columns)) if should_by_pass else pudf(*columns),
                     column_labels=[(SPARK_DEFAULT_SERIES_NAME,)],
+                    data_spark_columns=[
+                        (pudf(F.struct(*columns)) if should_by_pass else pudf(*columns)).alias(
+                            SPARK_DEFAULT_SERIES_NAME
+                        )
+                    ],
                     column_label_names=None,
                 )
-                return Series(internal, anchor=self)
+                return first_series(DataFrame(internal))
             else:
                 self_applied = DataFrame(self._internal.resolved_copy)
 
@@ -2951,8 +3033,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3       NaN
         """
         result = self[item]
-        self._internal = self.drop(item)._internal
-
+        self._update_internal_frame(self.drop(item)._internal)
         return result
 
     # TODO: add axis parameter can work when '1' or 'columns'
@@ -3059,8 +3140,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = self._internal.spark_frame.filter(reduce(lambda x, y: x & y, rows)).select(scols)
 
         if len(key) == len(self._internal.index_spark_columns):
-            result = first_series(DataFrame(InternalFrame(spark_frame=sdf, index_map=None)).T)
-            result.name = key
+            result = first_series(
+                DataFrame(InternalFrame(spark_frame=sdf, index_map=None)).T
+            ).rename(key)
         else:
             new_index_map = OrderedDict(
                 list(self._internal.index_map.items())[:level]
@@ -3496,7 +3578,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         if inplace:
-            self._internal = internal
+            self._update_internal_frame(internal)
         else:
             return DataFrame(internal)
 
@@ -3767,7 +3849,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         if inplace:
-            self._internal = internal
+            self._update_internal_frame(internal)
         else:
             return DataFrame(internal)
 
@@ -4804,7 +4886,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1  3  5  7
         1  2  4  6  8
         """
-        return DataFrame(self._internal.copy())
+        return DataFrame(self._internal)
 
     def dropna(self, axis=0, how="any", thresh=None, subset=None, inplace=False):
         """
@@ -4927,7 +5009,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             internal = self._internal.with_filter(pred)
             if inplace:
-                self._internal = internal
+                self._update_internal_frame(internal)
             else:
                 return DataFrame(internal)
 
@@ -5054,7 +5136,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = self._apply_series_op(op)
         if inplace:
-            self._internal = kdf._internal
+            self._update_internal_frame(kdf._internal)
         else:
             return kdf
 
@@ -5172,7 +5254,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = self._apply_series_op(op)
         if inplace:
-            self._internal = kdf._internal
+            self._update_internal_frame(kdf._internal)
         else:
             return kdf
 
@@ -5728,8 +5810,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             self._internal.spark_column_for(label).alias(name)
             for label, name in zip(self._internal.column_labels, data_columns)
         ]
-        self._internal = self._internal.with_new_columns(
-            data_spark_columns, column_labels=column_labels, column_label_names=column_label_names
+        self._update_internal_frame(
+            self._internal.with_new_columns(
+                data_spark_columns,
+                column_labels=column_labels,
+                column_label_names=column_label_names,
+            )
         )
 
     @property
@@ -6158,7 +6244,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = self._internal.resolved_copy.spark_frame.sort(*(by + [NATURAL_ORDER_COLUMN_NAME]))
         kdf = DataFrame(self._internal.with_new_sdf(sdf))  # type: ks.DataFrame
         if inplace:
-            self._internal = kdf._internal
+            self._update_internal_frame(kdf._internal)
             return None
         else:
             return kdf
@@ -7180,7 +7266,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             raise NotImplementedError("Only left join is supported")
 
         if isinstance(other, ks.Series):
-            other = DataFrame(other)
+            other = other.to_frame()
 
         update_columns = list(
             set(self._internal.column_labels).intersection(set(other._internal.column_labels))
@@ -7208,7 +7294,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             + list(HIDDEN_COLUMNS)
         )
         internal = self._internal.with_new_sdf(sdf)
-        self._internal = internal
+        self._update_internal_frame(internal, requires_same_anchor=False)
 
     def sample(
         self,
@@ -7718,7 +7804,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         sdf = sdf.where(~scol_for(sdf, column)).drop(column)
         internal = self._internal.with_new_sdf(sdf)
         if inplace:
-            self._internal = internal
+            self._update_internal_frame(internal)
         else:
             return DataFrame(internal)
 
@@ -9123,7 +9209,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ]
             internal = internal.with_new_columns(new_data_scols, column_labels=new_column_labels)
         if inplace:
-            self._internal = internal
+            self._update_internal_frame(internal)
         else:
             return DataFrame(internal)
 
@@ -9696,7 +9782,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = self._internal.with_new_sdf(sdf, data_columns=data_columns)
 
         if inplace:
-            self._internal = internal
+            self._update_internal_frame(internal)
         else:
             return DataFrame(internal)
 
@@ -9896,7 +9982,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if inplace:
             # Here, the result is always a frame because the error is thrown during schema inference
             # from pandas.
-            self._internal = result._internal
+            self._update_internal_frame(result._internal, requires_same_anchor=False)
         elif should_return_series:
             return first_series(result)
         elif should_return_scalar:
@@ -10041,13 +10127,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 return pd.concat(cols, axis=1).mad(axis=1)
 
             internal = self._internal.copy(
-                spark_column=calculate_columns_axis(*self._internal.data_spark_columns).alias(
-                    SPARK_DEFAULT_SERIES_NAME
-                ),
                 column_labels=[(SPARK_DEFAULT_SERIES_NAME,)],
+                data_spark_columns=[
+                    calculate_columns_axis(*self._internal.data_spark_columns).alias(
+                        SPARK_DEFAULT_SERIES_NAME
+                    )
+                ],
                 column_label_names=None,
             )
-            return Series(internal, anchor=self)
+            return first_series(DataFrame(internal))
 
     def _to_internal_pandas(self):
         """
@@ -10058,14 +10146,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._internal.to_pandas_frame
 
     def _get_or_create_repr_pandas_cache(self, n):
-        if (
-            not hasattr(self, "_repr_pandas_cache")
-            or (id(self._internal), n) not in self._repr_pandas_cache
-        ):
-            self._repr_pandas_cache = {
-                (id(self._internal), n): self.head(n + 1)._to_internal_pandas()
-            }
-        return self._repr_pandas_cache[(id(self._internal), n)]
+        if not hasattr(self, "_repr_pandas_cache") or n not in self._repr_pandas_cache:
+            self._repr_pandas_cache = {n: self.head(n + 1)._to_internal_pandas()}
+        return self._repr_pandas_cache[n]
 
     def __repr__(self):
         max_display_count = get_option("display.max_rows")
@@ -10158,7 +10241,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # Same Series.
             kdf = self._assign({key: value})
 
-        self._internal = kdf._internal
+        self._update_internal_frame(kdf._internal)
 
     def _index_normalized_label(self, labels):
         """

--- a/databricks/koalas/generic.py
+++ b/databricks/koalas/generic.py
@@ -17,12 +17,13 @@
 """
 A base class to be monkey-patched to DataFrame/Column to behave similar to pandas DataFrame/Series.
 """
-import warnings
+from abc import ABCMeta, abstractmethod
 from collections import Counter
 from collections.abc import Iterable
 from distutils.version import LooseVersion
 from functools import reduce
 from typing import Optional, Union, List
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -45,13 +46,15 @@ from databricks.koalas.utils import (
 from databricks.koalas.window import Rolling, Expanding
 
 
-class Frame(object):
+class Frame(object, metaclass=ABCMeta):
     """
     The base class for both DataFrame and Series.
     """
 
-    def __init__(self, internal: InternalFrame):
-        self._internal = internal  # type: InternalFrame
+    @property
+    @abstractmethod
+    def _internal(self) -> InternalFrame:
+        pass
 
     # TODO: add 'axis' parameter
     def cummin(self, skipna: bool = True):

--- a/databricks/koalas/groupby.py
+++ b/databricks/koalas/groupby.py
@@ -1240,7 +1240,7 @@ class GroupBy(object):
                 # if we should restore the index or not. For instance, see the example in
                 # https://github.com/databricks/koalas/issues/628.
 
-                # TODO: deduplicate this logic with _InternalFrame.from_pandas
+                # TODO: deduplicate this logic with InternalFrame.from_pandas
                 new_index_columns = [
                     SPARK_INDEX_NAME_FORMAT(i) for i in range(len(pdf.index.names))
                 ]

--- a/databricks/koalas/internal.py
+++ b/databricks/koalas/internal.py
@@ -812,12 +812,12 @@ class InternalFrame(object):
     def with_new_sdf(
         self, spark_frame: spark.DataFrame, data_columns: Optional[List[str]] = None
     ) -> "InternalFrame":
-        """ Copy the immutable _InternalFrame with the updates by the specified Spark DataFrame.
+        """ Copy the immutable InternalFrame with the updates by the specified Spark DataFrame.
 
         :param spark_frame: the new Spark DataFrame
         :param data_columns: the new column names.
             If None, the original one is used.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         assert self.spark_column is None
 
@@ -841,13 +841,13 @@ class InternalFrame(object):
         keep_order: bool = True,
     ) -> "InternalFrame":
         """
-        Copy the immutable _InternalFrame with the updates by the specified Spark Columns or Series.
+        Copy the immutable InternalFrame with the updates by the specified Spark Columns or Series.
 
         :param scols_or_ksers: the new Spark Columns or Series.
         :param column_labels: the new column index.
             If None, the its column_labels is used when the corresponding `scols_or_ksers` is
             Series, otherwise the original one is used.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         from databricks.koalas.series import Series
 
@@ -898,10 +898,10 @@ class InternalFrame(object):
         )
 
     def with_filter(self, pred: Union[spark.Column, "Series"]):
-        """ Copy the immutable _InternalFrame with the updates by the predicate.
+        """ Copy the immutable InternalFrame with the updates by the predicate.
 
         :param pred: the predicate to filter.
-        :return: the copied _InternalFrame.
+        :return: the copied InternalFrame.
         """
         from databricks.koalas.series import Series
 
@@ -920,6 +920,22 @@ class InternalFrame(object):
                 spark_frame=sdf, spark_column=scol_for(sdf, self.data_spark_column_names[0])
             )
 
+    def with_new_spark_column(
+        self, column_label: Tuple[str, ...], scol: spark.Column, keep_order: bool = True
+    ):
+        """
+        Copy the immutable InternalFrame with the updates by the specified Spark Column.
+
+        :param column_label: the column label to be updated.
+        :param scol: the new Spark Column
+        """
+        assert column_label in self.column_labels, column_label
+
+        idx = self.column_labels.index(column_label)
+        data_spark_columns = self.data_spark_columns.copy()
+        data_spark_columns[idx] = scol
+        return self.with_new_columns(data_spark_columns, keep_order=keep_order)
+
     def copy(
         self,
         spark_frame: Union[spark.DataFrame, _NoValueType] = _NoValue,
@@ -929,7 +945,7 @@ class InternalFrame(object):
         column_label_names: Optional[Union[List[str], _NoValueType]] = _NoValue,
         spark_column: Optional[Union[spark.Column, _NoValueType]] = _NoValue,
     ) -> "InternalFrame":
-        """ Copy the immutable DataFrame.
+        """ Copy the immutable InternalFrame.
 
         :param spark_frame: the new Spark DataFrame. If None, then the original one is used.
         :param index_map: the new index information. If None, then the original one is used.
@@ -937,7 +953,7 @@ class InternalFrame(object):
         :param data_spark_columns: the new Spark Columns. If None, then the original ones are used.
         :param column_label_names: the new names of the index levels.
         :param spark_column: the new Spark Column. If None, then the original one is used.
-        :return: the copied immutable DataFrame.
+        :return: the copied immutable InternalFrame.
         """
         if spark_frame is _NoValue:
             spark_frame = self.spark_frame

--- a/databricks/koalas/mlflow.py
+++ b/databricks/koalas/mlflow.py
@@ -24,7 +24,8 @@ import numpy as np
 from typing import Any
 
 from databricks.koalas.utils import lazy_property, default_session
-from databricks.koalas import Series, DataFrame
+from databricks.koalas.frame import DataFrame
+from databricks.koalas.series import first_series
 from databricks.koalas.typedef import as_spark_type
 
 __all__ = ["PythonModelWrapper", "load_model"]
@@ -93,10 +94,10 @@ class PythonModelWrapper(object):
             column_labels = [
                 (col,) for col in data._internal.spark_frame.select(return_col).columns
             ]
-            return Series(
-                data._internal.copy(spark_column=return_col, column_labels=column_labels),
-                anchor=data,
+            internal = data._internal.copy(
+                column_labels=column_labels, data_spark_columns=[return_col]
             )
+            return first_series(DataFrame(internal))
 
 
 def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:

--- a/databricks/koalas/spark/accessors.py
+++ b/databricks/koalas/spark/accessors.py
@@ -443,7 +443,9 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
-        self._kdf._internal = self._kdf._internal.resolved_copy
+        self._kdf._update_internal_frame(
+            self._kdf._internal.resolved_copy, requires_same_anchor=False
+        )
         return CachedDataFrame(self._kdf._internal)
 
     def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK):
@@ -517,6 +519,9 @@ class SparkFrameMethods(object):
         """
         from databricks.koalas.frame import CachedDataFrame
 
+        self._kdf._update_internal_frame(
+            self._kdf._internal.resolved_copy, requires_same_anchor=False
+        )
         return CachedDataFrame(self._kdf._internal, storage_level=storage_level)
 
     def hint(self, name: str, *parameters) -> "ks.DataFrame":

--- a/databricks/koalas/tests/test_indexes.py
+++ b/databricks/koalas/tests/test_indexes.py
@@ -128,8 +128,11 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertIsNone(kdf.index.name)
 
         idx = pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name="x")
-        pdf = pd.DataFrame(np.random.randn(10, 5), idx)
+        pdf = pd.DataFrame(np.random.randn(10, 5), index=idx, columns=list("abcde"))
         kdf = ks.from_pandas(pdf)
+
+        pser = pdf.a
+        kser = kdf.a
 
         self.assertEqual(kdf.index.name, pdf.index.name)
         self.assertEqual(kdf.index.names, pdf.index.names)
@@ -141,12 +144,18 @@ class IndexesTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(kidx.name, pidx.name)
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
+        self.assertEqual(kdf.index.name, pdf.index.name)
+        self.assertEqual(kdf.index.names, pdf.index.names)
+        self.assertEqual(kser.index.names, pser.index.names)
 
         pidx.name = None
         kidx.name = None
         self.assertEqual(kidx.name, pidx.name)
         self.assertEqual(kidx.names, pidx.names)
         self.assert_eq(kidx, pidx)
+        self.assertEqual(kdf.index.name, pdf.index.name)
+        self.assertEqual(kdf.index.names, pdf.index.names)
+        self.assertEqual(kser.index.names, pser.index.names)
 
         with self.assertRaisesRegex(ValueError, "Names must be a list-like"):
             kidx.names = "hi"

--- a/databricks/koalas/tests/test_ops_on_diff_frames.py
+++ b/databricks/koalas/tests/test_ops_on_diff_frames.py
@@ -422,17 +422,23 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def test_assignment_series(self):
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf["a"] = self.kdf2.a
         pdf["a"] = self.pdf2.a
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf["a"] = self.kdf2.b
         pdf["a"] = self.pdf2.b
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
@@ -455,18 +461,24 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
     def test_assignment_frame(self):
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf[["a", "b"]] = self.kdf1
         pdf[["a", "b"]] = self.pdf1
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         # 'c' does not exist in `kdf`.
         kdf = ks.from_pandas(self.pdf1)
         pdf = self.pdf1
+        kser = kdf.a
+        pser = pdf.a
         kdf[["b", "c"]] = self.kdf1
         pdf[["b", "c"]] = self.pdf1
 
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
+        self.assert_eq(kser, pser)
 
         # 'c' and 'd' do not exist in `kdf`.
         kdf = ks.from_pandas(self.pdf1)
@@ -600,23 +612,42 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
+
         another_kdf = ks.DataFrame(pdf_orig)
 
         kdf.loc[["viper", "sidewinder"], ["shield"]] = -another_kdf.max_speed
         pdf.loc[["viper", "sidewinder"], ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
         kdf.loc[another_kdf.max_speed < 5, ["shield"]] = -kdf.max_speed
         pdf.loc[pdf.max_speed < 5, ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
         pdf = pdf_orig.copy()
         kdf = kdf_orig.copy()
+        pser1 = pdf.max_speed
+        pser2 = pdf.shield
+        kser1 = kdf.max_speed
+        kser2 = kdf.shield
         kdf.loc[another_kdf.max_speed < 5, ["shield"]] = -another_kdf.max_speed
         pdf.loc[pdf.max_speed < 5, ["shield"]] = -pdf.max_speed
         self.assert_eq(kdf, pdf)
+        self.assert_eq(kser1, pser1)
+        self.assert_eq(kser2, pser2)
 
     def test_frame_iloc_setitem(self):
         pdf = pd.DataFrame(
@@ -636,8 +667,12 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
 
     def test_series_loc_setitem(self):
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         pser_another = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
         kser_another = ks.from_pandas(pser_another)
@@ -645,40 +680,77 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser.loc[kser % 2 == 1] = -kser_another
         pser.loc[pser % 2 == 1] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser
         pser.loc[pser_another % 2 == 1] = -pser
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = -kser_another
         pser.loc[pser_another % 2 == 1] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[["viper", "sidewinder"]] = -kser_another
         pser.loc[["viper", "sidewinder"]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
         kser.loc[kser_another % 2 == 1] = 10
         pser.loc[pser_another % 2 == 1] = 10
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
     def test_series_iloc_setitem(self):
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         pser1 = pser + 1
         kser1 = kser + 1
@@ -689,17 +761,28 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kser.iloc[[1, 2]] = -kser_another
         pser.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kser.iloc[[0]] = 10 * kser_another
         pser.iloc[[0]] = 10 * pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kser1.iloc[[1, 2]] = -kser_another
         pser1.iloc[[1, 2]] = -pser_another
         self.assert_eq(kser1, pser1)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
-        pser = pd.Series([1, 2, 3], index=["cobra", "viper", "sidewinder"])
-        kser = ks.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}, index=["cobra", "viper", "sidewinder"])
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        psery = pdf.y
+        kser = kdf.x
+        ksery = kdf.y
 
         piloc = pser.iloc
         kiloc = kser.iloc
@@ -707,10 +790,25 @@ class OpsOnDiffFramesEnabledTest(ReusedSQLTestCase, SQLTestUtils):
         kiloc[[1, 2]] = -kser_another
         piloc[[1, 2]] = -pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
 
         kiloc[[0]] = 10 * kser_another
         piloc[[0]] = 10 * pser_another
         self.assert_eq(kser, pser)
+        self.assert_eq(kdf, pdf)
+        self.assert_eq(ksery, psery)
+
+    def test_update(self):
+        pdf = pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})
+        kdf = ks.from_pandas(pdf)
+
+        pser = pdf.x
+        kser = kdf.x
+        pser.update(pd.Series([4, 5, 6]))
+        kser.update(ks.Series([4, 5, 6]))
+        self.assert_eq(kser.sort_index(), pser.sort_index())
+        self.assert_eq(kdf.sort_index(), pdf.sort_index())
 
     def test_where(self):
         pdf1 = pd.DataFrame({"A": [0, 1, 2, 3, 4], "B": [100, 200, 300, 400, 500]})


### PR DESCRIPTION
Recreated from original PR: https://github.com/databricks/koalas/pull/1592

Making `DataFrame` and `Series`/`Index` manage the connection with each other to support inplace updates.

`Series` and `Index` don't manage its own `InternalFrame` anymore, basically they refer the anchor `DataFrame` and create the `InternalFrame` only when needed.

E.g.,

```py
>>> pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6], "y": [np.nan, 2, 3, 4, np.nan, 6]})
>>> pser = pdf.x
>>> pser.fillna(0, inplace=True)
>>> pser
0    0.0
1    2.0
2    3.0
3    4.0
4    0.0
5   ...